### PR TITLE
Add --no-fehbg flag to feh command

### DIFF
--- a/back4.sh
+++ b/back4.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-select1='feh --bg-fill'
+select1='feh --bg-fill --no-fehbg'
 select2='xwallpaper --zoom'
 select3='xloadimage -onroot -fullscreen'
 select4='xfconf-query -c xfce4-desktop -p /backdrop/screen0/monitor0/workspace0/last-image -s'


### PR DESCRIPTION
## Background
By default, `feh --bg-fill` writes to an executable file in the user's home directory called `~/.fehbg`. This file can be included in the display server startup (`xinit`, etc) to restore the background after a reboot. Since this script effectively replaces `~/.fehbg`, writing that file is unnecessary, and results in increased disk I/O (potentially hundreds of writes per minute, depending on the background refresh interval).

## Purpose
Add the `--no-fehbg` flag to the `feh` command so the `~/.fehbg` file is not written.

## Result
Below is a very imperfect observation using `tload` that indicates this _might_ slightly reduce the CPU load.
![screenshot_annotated](https://user-images.githubusercontent.com/9148542/104833250-249d9d00-584c-11eb-90ff-98dbc4cc3207.jpg)

Thanks for the handy script!
